### PR TITLE
Fix url preview in a multi-site and multi-language setup

### DIFF
--- a/app/scripts/controllers/metadata.controller.js
+++ b/app/scripts/controllers/metadata.controller.js
@@ -52,7 +52,7 @@ angular.module("umbraco").controller("EpiphanySeoMetadataController", [
               }
           }
           else if ($scope.model.value.urlName && $scope.model.value.urlName.length) {
-              if (!url.published) {
+              if (!parentContent.published) {
                   url = $scope.ProtocolAndHost() + '/unpublished-page/';
               } else {
                   url = $scope.ProtocolAndHost() + '/' + slugify($scope.model.value.urlName) + '/';


### PR DESCRIPTION
This ensure to use site domain if one exists, so the preview is correct in a multi-site and multi-language setup.

It also slugify the urlName, although not perfect.
You can also choose the inject a module, service, filter like https://github.com/paulsmith/angular-slugify instead of the slugify function in this PR.
However in e.g. the service it replace the danish "ø" with "o", where Umbraco replace "ø" with "oe".

Another approach might be to add a filter the urlName input, so it filter chars. For instance I made a camelCase filter for my package Color Palettes that works similar to when you enter a property name in doctypes. https://github.com/bjarnef/color-palettes/blob/master/ColorPalettes/ColorPalettes/ColorPalettes/filters/camelcase.js

You probably just want lowercase character, trim spaces, replace a single space and "&" with "-", etc.
I don't think Umbraco has a filter or service for that part, but if you take a look at the source code, you might find how Umbraco on serverside replace nodename to a safe url.
