### PR TITLE
JJCLane - adding default site title

### DIFF
--- a/app/scripts/controllers/metadata.controller.js
+++ b/app/scripts/controllers/metadata.controller.js
@@ -7,6 +7,7 @@ angular.module("umbraco").controller("EpiphanySeoMetadataController", [
     $scope.serpDescriptionLength = !!$scope.model.config.serpDescriptionLength ? $scope.model.config.serpDescriptionLength : 150;
     $scope.developerName = $scope.model.config.developerName || 'your agency';
     $scope.doNotIndexExplanation = $scope.model.config.doNotIndexExplanation || '';
+    $scope.siteTitle = $scope.model.config.siteTitle || '';
 
     // default model.value
     if (!$scope.model.value) {
@@ -22,6 +23,17 @@ angular.module("umbraco").controller("EpiphanySeoMetadataController", [
       }
 
       return $scope.ProtocolAndHost() + urlName;
+
+    };
+    
+    $scope.GetTitle = function () {
+
+        var title = $scope.model.value.title || 'Page Title';
+
+        if (title !== 'Page Title' && $scope.siteTitle !== '') {
+            title += $scope.siteTitle.replace('&nbsp;', ' ');
+        }
+        return title;
 
     };
 

--- a/app/views/epiphany.seo.metadata.html
+++ b/app/views/epiphany.seo.metadata.html
@@ -63,7 +63,7 @@
 
                 <img src="/App_Plugins/Epiphany.SeoMetadata/views/serp1.png" alt=""/>
                 <div class="listing">
-                    <h3>{{ model.value.title || 'Page Title' | ellipsisLimit:serpTitleLength}}</h3>
+                    <h3>{{ GetTitle() || 'Page Title' | ellipsisLimit:serpTitleLength}}</h3>
                     <a>{{ GetUrl() }} <i class="icon icon-navigation-down"></i></a>
                     <p>{{ model.value.description || 'My Nice Description of this Page' | ellipsisLimit:serpDescriptionLength }}</p>
                 </div>

--- a/config/package.manifest
+++ b/config/package.manifest
@@ -40,6 +40,12 @@
             "view": "textstring"
           },
           {
+            "label": "Site Title",
+            "description": "The default title that should be appended to the title e.g. &nbsp;| My Company",
+            "key": "siteTitle",
+            "view": "textstring"
+          },
+          {
             "label": "Do Not Index explanation",
             "description": "An explanation what the effect of checking 'Do Not Index' is. This is used in the help description.",
             "key": "doNotIndexExplanation",


### PR DESCRIPTION
Added the ability to define a default site title which is appended to the end of the title preview to get a more accurate representation of the title as requested here: https://github.com/ryanlewis/seo-metadata/issues/16
