### PR TITLE
Prevent looking up parent URL for root content

### DIFF
--- a/app/scripts/controllers/metadata.controller.js
+++ b/app/scripts/controllers/metadata.controller.js
@@ -28,7 +28,7 @@ angular.module("umbraco")
 
             $scope.init = function() {
                 var content = $scope.GetParentContent();
-                if (!content.published) {
+                if (!content.published && content.parentId !== -1) {
                     // get the URL of the parent document for later
                     contentResource.getById(content.parentId).then(function(data) {
                         $scope.parentUrl = data.urls[0];
@@ -53,7 +53,7 @@ angular.module("umbraco")
                         name = "unpublished-page";
                     }
 
-                    return $scope.ProtocolAndHost() + $scope.parentUrl + name + "/";
+                    return $scope.ProtocolAndHost() + ($scope.parentUrl || "") + name + "/";
                 }
 
                 var nodeUrl = pageContent.urls[0];


### PR DESCRIPTION
Prevents a 404 error when looking for a parent content node for nodes at the root.